### PR TITLE
Fix StoreLocatorViewService bug cases

### DIFF
--- a/src/Orckestra.Composer.Store/Api/StoreLocatorController.cs
+++ b/src/Orckestra.Composer.Store/Api/StoreLocatorController.cs
@@ -87,7 +87,7 @@ namespace Orckestra.Composer.Store.Api
                 IncludeMarkers = true
             }).ConfigureAwait(false);
 
-            if (request.IsSearch && (vm.Markers == null || !vm.Markers.Any()) && vm.NearestStoreCoordinate != null)
+            if (request.IsSearch && !vm.Markers.Any() && vm.NearestStoreCoordinate != null)
             {
                 // if no markers in requested search bounds, return the coordinates of the nearest store, so always see one store on the map
                 return Ok(vm.NearestStoreCoordinate.GetCoordinate());

--- a/src/Orckestra.Composer.Store/Api/StoreLocatorController.cs
+++ b/src/Orckestra.Composer.Store/Api/StoreLocatorController.cs
@@ -87,7 +87,7 @@ namespace Orckestra.Composer.Store.Api
                 IncludeMarkers = true
             }).ConfigureAwait(false);
 
-            if (request.IsSearch && !vm.Markers.Any() && vm.NearestStoreCoordinate != null)
+            if (request.IsSearch && (vm.Markers == null || !vm.Markers.Any()) && vm.NearestStoreCoordinate != null)
             {
                 // if no markers in requested search bounds, return the coordinates of the nearest store, so always see one store on the map
                 return Ok(vm.NearestStoreCoordinate.GetCoordinate());

--- a/src/Orckestra.Composer.Store/Extentions/StoreExtensions.cs
+++ b/src/Orckestra.Composer.Store/Extentions/StoreExtensions.cs
@@ -72,7 +72,7 @@ namespace Orckestra.Composer.Store.Extentions
                     && bound.Contains(address.Latitude.Value, address.Longitude.Value)
                 : false;
         }
-
+        //TODO: Rename from CalculateDestination to CalculateDistance
         public static double CalculateDestination(this Overture.ServiceModel.Customers.Stores.Store store, Coordinate searchPoint)
         {
             return store.HasLocation()


### PR DESCRIPTION
Fix GetStoreLocatorViewModelAsync method
- In case stores amount in scope initially will be null or empty (no stores in scope), passing null to `new StoreGeoCoordinate` will lead to an exception;
- Returning `NearestStoreCoordinate` in case there are no stores after filtering
- Keeping the order operation after filtering stores