### PR TITLE
Optimize Google API calls for billing purpose

### DIFF
--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/SingleCheckout/Steps/PickUpAddress.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/SingleCheckout/Steps/PickUpAddress.cshtml
@@ -41,8 +41,8 @@
     <div v-if="Errors.StoreLocatorLocationError" class="text-danger mb-2">@Html.Localize("Store", "L_MyLocationError")</div>
     <div class="form-group form-row align-items-center">
         <div class="col-12 col-md-6 mb-2 mb-md-0">
-            <input id="storeLocatorSearchInput"
-                   name="storeLocatorSearchInput"
+            <input id="storeLocatorAutocompleteInput"
+                   name="storeLocatorAutocompleteInput"
                    class="form-control" type="text"
                    placeholder="@Html.Localize("Store", "I_Placeholder")" />
             <i class="fa fa-search text-muted store-locator-search-icon" />

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Store/Locator.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Store/Locator.cshtml
@@ -45,7 +45,7 @@
     <div id="storeLocator" data-oc-controller="Store.Locator" class="store-locator w-100" data-pagesize="@PageSize">
         <div class="container-md">
             <div class="mt-3 mb-2">
-                @SearchStoreInput(@storeLocatorViewModel.PostedAddress)
+                @SearchStoreAutocompleteInput(@storeLocatorViewModel.PostedAddress)
             </div>
         </div>
         <div class="container-fluid">
@@ -76,13 +76,13 @@
 </body>
 </html>
 
-@helper SearchStoreInput(string postedAddress)
+@helper SearchStoreAutocompleteInput(string postedAddress)
 {
     <div v-if="StoreLocatorLocationError" class="text-danger mb-2">@Html.Localize("Store", "L_MyLocationError")</div>
     <div class="form-group form-row align-items-center">
         <div class="col-12 col-md-6 col-lg-4 mb-2 mb-md-0">
-            <input id="storeLocatorSearchInput"
-                   name="storeLocatorSearchInput"
+            <input id="storeLocatorAutocompleteInput"
+                   name="storeLocatorAutocompleteInput"
                    class="form-control" type="text"
                    placeholder="@Html.Localize("Store", "I_Placeholder")"
                    value="@postedAddress" />

--- a/src/Orckestra.Composer.Website/UI.Package/Typings/googlemaps/google.maps.d.ts
+++ b/src/Orckestra.Composer.Website/UI.Package/Typings/googlemaps/google.maps.d.ts
@@ -1815,6 +1815,7 @@ declare module google.maps {
             bounds?: LatLngBounds;
             componentRestrictions?: ComponentRestrictions;
             types?: string[];
+            fields: string[];
         }
 
         export interface AutocompletePrediction {


### PR DESCRIPTION
- Use **Autocomplete** widget instead of SearcBox widget - according to Google Docs this widget automatically handle user sessions on background, so no matter how many user type, just one API call should be billed. - https://developers.google.com/maps/documentation/javascript/places-autocomplete#session_tokens

 - Limit Place details to get just Geometry data - other data not needed - it is also to reduce bill per PlaceDetails request 