### PR TITLE
Bugs/50197 sitemap multi instance support

### DIFF
--- a/src/Orckestra.Composer.Sitemap/EventHandlers/CommonEventMessageProcessor.cs
+++ b/src/Orckestra.Composer.Sitemap/EventHandlers/CommonEventMessageProcessor.cs
@@ -12,7 +12,7 @@ namespace Orckestra.Composer.Sitemap.EventHandlers
 
         public Action Action { set; get; }
 
-        public async Task ProcessMessageAsync(BrokeredMessage message, CancellationToken cancellationToken)
+        public Task ProcessMessageAsync(BrokeredMessage message, CancellationToken cancellationToken)
         {
             if (EventName == null) throw new ArgumentException(nameof(EventName));
             if (Action == null) throw new ArgumentException(nameof(Action));
@@ -21,6 +21,8 @@ namespace Orckestra.Composer.Sitemap.EventHandlers
             {
                 Action();
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Orckestra.Composer.Sitemap/EventHandlers/SitemapEventRegistrator.cs
+++ b/src/Orckestra.Composer.Sitemap/EventHandlers/SitemapEventRegistrator.cs
@@ -1,16 +1,16 @@
-﻿using Composite.Core;
+﻿using Composite.C1Console.Events;
+using Composite.Core;
 using Composite.Data;
 using Composite.Data.Types;
 using Orckestra.Composer.CompositeC1.Sitemap;
 using Orckestra.Composer.Sitemap.Services;
+using Orckestra.Composer.Utils;
 using Orckestra.ExperienceManagement.Configuration.ServiceBus;
 using Orckestra.ExperienceManagement.Configuration.Settings;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Composite.C1Console.Events;
-using Orckestra.Composer.Utils;
 
 namespace Orckestra.Composer.Sitemap.EventHandlers
 {
@@ -19,6 +19,9 @@ namespace Orckestra.Composer.Sitemap.EventHandlers
         private static readonly ISitemapGeneratorScheduler SitemapGeneratorScheduler;
         private static readonly ServiceBusListener ServiceBusListener;
         private static IEnumerable<string> _dataTypesToIncludeFromConfig = C1ContentSitemapProviderConfig.DataTypesToInclude;
+
+        private const int WaitingForCancellationTimeInMs = 5000;
+        private const int WaitingTimeForCancellationToFinishInMs = 5000;
 
         static SitemapEventRegistrator()
         {
@@ -39,7 +42,7 @@ namespace Orckestra.Composer.Sitemap.EventHandlers
                 try
                 {
                     cts.Cancel();
-                    task.Wait(5000);
+                    task.Wait(WaitingTimeForCancellationToFinishInMs);
                 }
                 catch (Exception ex)
                 {
@@ -63,7 +66,7 @@ namespace Orckestra.Composer.Sitemap.EventHandlers
 
                 try
                 {
-                    await Task.Delay(5000, cancellationToken);
+                    await Task.Delay(WaitingForCancellationTimeInMs, cancellationToken);
                 }
                 catch (TaskCanceledException) {}
             }
@@ -80,7 +83,7 @@ namespace Orckestra.Composer.Sitemap.EventHandlers
             {
                 try
                 {
-                    await Task.Delay(5000, cancellationToken);
+                    await Task.Delay(WaitingForCancellationTimeInMs, cancellationToken);
                 }
                 catch (TaskCanceledException) { }
             }

--- a/src/Orckestra.Composer.Sitemap/EventHandlers/SitemapEventRegistrator.cs
+++ b/src/Orckestra.Composer.Sitemap/EventHandlers/SitemapEventRegistrator.cs
@@ -7,6 +7,10 @@ using Orckestra.ExperienceManagement.Configuration.ServiceBus;
 using Orckestra.ExperienceManagement.Configuration.Settings;
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Composite.C1Console.Events;
+using Orckestra.Composer.Utils;
 
 namespace Orckestra.Composer.Sitemap.EventHandlers
 {
@@ -26,15 +30,82 @@ namespace Orckestra.Composer.Sitemap.EventHandlers
 
         public static void Initialize()
         {
-            ServiceBusListener.Register(new CommonEventMessageProcessor()
+            SubscribeToDataEvents();
+
+            var cts = new CancellationTokenSource();
+            var task = Task.Run(() => WaitForWriteLockAndStartServiceBusListener(cts.Token));
+            GlobalEventSystemFacade.SubscribeToPrepareForShutDownEvent(args =>
+            {
+                try
+                {
+                    cts.Cancel();
+                    task.Wait(5000);
+                }
+                catch (Exception ex)
+                {
+                    Log.LogError(nameof(SitemapEventRegistrator), ex);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Repeatedly tries to acquire a write lock, when successful - starts a ServiceBus listener
+        /// </summary>
+        /// <returns></returns>
+        private static async Task WaitForWriteLockAndStartServiceBusListener(CancellationToken cancellationToken)
+        {
+            IDisposable writeLock = null;
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                writeLock = FileWriteLock.TryAcquire(nameof(SitemapEventRegistrator));
+
+                if (writeLock != null) break;
+
+                try
+                {
+                    await Task.Delay(5000, cancellationToken);
+                }
+                catch (TaskCanceledException) {}
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                writeLock?.Dispose();
+                return;
+            }
+
+            StartServiceBusListener();
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(5000, cancellationToken);
+                }
+                catch (TaskCanceledException) { }
+            }
+
+            writeLock?.Dispose();
+        }
+
+        /// <summary>
+        /// Starts a ServiceBus listener, that triggers (with debounce) a sitemap regeneration on ProductUpdateEvent.
+        /// </summary>
+        private static void StartServiceBusListener()
+        {
+            ServiceBusListener.Register(new CommonEventMessageProcessor
             {
                 EventName = "ProductUpdatedEvent",
                 Action = SitemapGeneratorScheduler.RegenerateSitemapJob
             });
             ServiceBusListener.Start();
+        }
 
-            DataEvents<IPage>.OnAfterAdd += new DataEventHandler(SitemapUpdateAfterPageChanged);
-            DataEvents<IPage>.OnDeleted += new DataEventHandler(SitemapUpdateAfterPageChanged);
+        private static void SubscribeToDataEvents()
+        {
+
+            DataEvents<IPage>.OnAfterAdd += SitemapUpdateAfterPageChanged;
+            DataEvents<IPage>.OnDeleted += SitemapUpdateAfterPageChanged;
 
             foreach (var typeFullName in _dataTypesToIncludeFromConfig)
             {

--- a/src/Orckestra.Composer/Orckestra.Composer.csproj
+++ b/src/Orckestra.Composer/Orckestra.Composer.csproj
@@ -333,6 +333,7 @@
     <Compile Include="Services\ScopeViewService.cs" />
     <Compile Include="Utils\Constants.cs" />
     <Compile Include="Utils\ExpressionUtility.cs" />
+    <Compile Include="Utils\FileWriteLock.cs" />
     <Compile Include="Utils\LineItemHelper.cs" />
     <Compile Include="Utils\MessagesHelper.cs" />
     <Compile Include="Utils\MvcFilterRedirectUtil.cs" />

--- a/src/Orckestra.Composer/Utils/FileWriteLock.cs
+++ b/src/Orckestra.Composer/Utils/FileWriteLock.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Composite.Core.Configuration;
+using Composite.Core.IO;
+
+namespace Orckestra.Composer.Utils
+{
+    /// <summary>
+    /// Allows creating a "write" lock on a local file.
+    /// Can be used for multi-instance deployments with a shared network drive, to ensure only one instance is running a certain operation.
+    /// </summary>
+    public class FileWriteLock : IDisposable
+    {
+        private FileStream _fileStream;
+
+        private FileWriteLock(FileStream fileStream)
+        {
+            _fileStream = fileStream ?? throw new ArgumentNullException(nameof(fileStream));
+        }
+
+        public void Dispose()
+        {
+            if (_fileStream == null) return;
+
+            var content = Encoding.UTF8.GetBytes($"Released at {DateTime.Now}\r\n");
+
+            _fileStream.Write(content, 0, content.Length);
+            _fileStream.Flush();
+            _fileStream.Dispose();
+            _fileStream = null;
+        }
+
+        /// <summary>
+        /// Tries to get a write access to a specific lock. If not successful, returns <value>null</value>.
+        /// </summary>
+        /// <param name="lockName">The name of the lock, should also be a valid filename. Could be the name of the class, that uses it.</param>
+        /// <returns></returns>
+        public static IDisposable TryAcquire(string lockName)
+        {
+            var filePath = Path.Combine(PathUtil.Resolve(GlobalSettingsFacade.TempDirectory), $"{lockName}.writelock");
+
+            try
+            {
+                var fileStream = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+
+                var content = Encoding.UTF8.GetBytes($"Acquired at {DateTime.Now}\r\n");
+
+                fileStream.Write(content, 0, content.Length);
+                fileStream.Flush();
+
+                return new FileWriteLock(fileStream);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Making sure that in multi-instance deployment environment with a shared network drive, only one instance at a time is updating sitemap xml. 
This both resolves an issue of sitemap getting deleted in certain conditions and improves website's peformance.