### PR TITLE
Fix Product Details Page

### DIFF
--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Product/Specifications.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Product/Specifications.cshtml
@@ -17,29 +17,59 @@
     {
         return Model.Variants == null || Model.Variants.Count == 0;
     }
+
+    public bool HasSpecifications()
+    {
+        if (IsWithoutVariants())
+        {
+            return Model.Specifications.Groups != null || Model.Specifications.Groups.Count != 0;
+        }
+        else
+        {
+            return HasVariantSpecifications() || Model.Specifications.Groups != null || Model.Specifications.Groups.Count != 0;
+        }
+    }
+
+    public bool HasVariantSpecifications()
+    {
+        var variantsSpecs = Model.Variants.Where(v => v.Specifications != null);
+        var hasSpecs = false;
+        foreach (var spec in variantsSpecs)
+        {
+            hasSpecs = hasSpecs || spec.Specifications.Groups.Count != 0;
+        }
+        return hasSpecs;
+    }
+
 }
 
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://www.composite.net/ns/function/1.0">
 <head>
 </head>
 <body>
+    @if (HasSpecifications())
+    {
         <div class="accordion">
-            <div class="specifications" data-toggle="collapse" href="#specifications" role="button" aria-expanded="false" aria-controls="specifications" >
+            <div class="specifications" data-toggle="collapse" href="#specifications" role="button" aria-expanded="false" aria-controls="specifications">
                 <h3>@Html.Localize("ProductPage", "L_ProductSpecifications")</h3>
                 <span class="fa fa-chevron-down"></span>
                 <span class="fa fa-chevron-up"></span>
             </div>
-            
+
             @Attributes()
         </div>
+    }
 </body>
 </html>
 
 @helper Attributes()
 {
+
     if (IsWithoutVariants())
     {
-        @AttributesTable(Model.Specifications)
+        <div class="specification-attributes collapse" id="specifications">
+            @AttributesTable(Model.Specifications)
+        </div>
     }
     else
     {
@@ -47,24 +77,45 @@
         foreach (var variant in variantsWithSpecs)
         {
             <div data-variant="@variant.Id" class="@SelectedVariantClass(variant.Id)">
-                @AttributesTable(variant.Specifications)
+                <div class="specification-attributes collapse" id="specifications">
+                    @AttributesTable(variant.Specifications)
+                </div>
             </div>
         }
 
         var inheritedVariantIds = Model.Variants.Where(v => v.Specifications == null).Select(v => v.Id).ToArray();
         if (inheritedVariantIds.Any())
         {
-            <div data-variant="@(String.Join(",", inheritedVariantIds))" class="@SelectedVariantClass(inheritedVariantIds)">
-                @AttributesTable(Model.Specifications)
-            </div>
+            foreach (var vid in inheritedVariantIds)
+            {
+                <div data-variant="@vid" class="@SelectedVariantClass(vid)">
+                    <div class="specification-attributes collapse" id="specifications">
+                        @AttributesTable(Model.Specifications)
+                        @KvaTable(Model.KeyVariantAttributeItems, vid)
+                    </div>
+                </div>
+            }
+        }
+        else
+        {
+            var variantsNoSpecs = Model.Variants.Where(v => v.Specifications == null);
+            foreach (var variant in variantsNoSpecs)
+            {
+                <div data-variant="@variant.Id" class="@SelectedVariantClass(variant.Id)">
+                    <div class="specification-attributes collapse" id="specifications">
+                        @AttributesTable(Model.Specifications)
+                        @KvaTable(Model.KeyVariantAttributeItems, variant.Id)
+                    </div>
+                </div>
+            }
         }
     }
 }
 
 @helper AttributesTable(SpecificationsViewModel specifications)
 {
-    <div class="specification-attributes collapse" id="specifications">
-        @foreach (var group in specifications.Groups)
+    
+        foreach (var group in specifications.Groups)
         {
             foreach (var attribute in group.Attributes)
             {
@@ -74,5 +125,32 @@
                 </div>
             }
         }
-    </div>
+}
+
+@helper KvaTable(List<KeyVariantAttributeItem> kvaAttributes, string variantId)
+{
+    foreach (KeyVariantAttributeItem kva in kvaAttributes)
+    {
+        KeyVariantAttributeItemValue kvaValue = null;
+        var kvaValues = kva.Values;
+        foreach (KeyVariantAttributeItemValue kvaVal in kvaValues)
+        {
+            foreach (var vid in kvaVal.RelatedVariantIds)
+            {
+                if (vid == variantId)
+                {
+                    kvaValue = kvaVal;
+                }
+            }
+        }
+
+        if (kvaValue != null)
+        {
+            <div class="specification-attributes-row">
+                <h6>@kva.DisplayName</h6>
+                <div>@kvaValue.Title</div>
+            </div>
+        }
+
+}
 }

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Product/Specifications.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Product/Specifications.cshtml
@@ -32,13 +32,7 @@
 
     public bool HasVariantSpecifications()
     {
-        var variantsSpecs = Model.Variants.Where(v => v.Specifications != null);
-        var hasSpecs = false;
-        foreach (var spec in variantsSpecs)
-        {
-            hasSpecs = hasSpecs || spec.Specifications.Groups.Count != 0;
-        }
-        return hasSpecs;
+        return Model.Variants.Where(v => v.Specifications != null && v.Specifications.Groups != null && v.Specifications.Groups.Count != 0).Any();
     }
 
 }

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Product/Summary.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Product/Summary.cshtml
@@ -34,7 +34,7 @@
          data-context-var="productDetailContext"
          class="product-details">
         <div class="row">
-            <div class="col-md-7 col-lg-8 mobile-carousel-container">
+            <div class="col-md-7 col-lg-8 @(Model.Images.Count > 1 ? "mobile-carousel-container" : "")">
                 @Partial("Product", "ImagesLargeGallery", Model)
             </div>
             <div class="mobile-carousel-thumbnails d-md-none">
@@ -92,7 +92,7 @@
         foreach (var group in displayNames)
         {
             var ids = group.Select(v => v.Id).ToArray();
-            <h1 data-variant="@(String.Join(",", ids))" class="@SelectedVariantClass(ids)">@group.Key</h1>
+            <span data-variant="@(String.Join(",", ids))" class="@SelectedVariantClass(ids) h1">@group.Key</span>
         }
         <h1 data-variant="unavailable" class="d-none">@Model.DisplayName</h1>
     }

--- a/src/Orckestra.Composer.Website/Views/Product/ImagesLargeGallery.cshtml
+++ b/src/Orckestra.Composer.Website/Views/Product/ImagesLargeGallery.cshtml
@@ -39,16 +39,16 @@
     </script>
 </head>
 <body>
-    <div class="row mobile-carousel">
+    <div class="row @(Model.Images.Count > 1 ? "mobile-carousel" : "")">
         
         <!-- Main image -->
        
         @if (Model.Variants == null || Model.Variants.Count == 0)
         {
-            
+            var ColumnClasses = (Model.Images.Count == 1) ? "col-12 col-lg-12 text-center" : "col-9 col-lg-6";
             foreach (var image in Model.Images)
             {
-                <div class="col-9 @GetFirstClass() col-lg-6" id="img-@CurIndex">
+                <div class="@ColumnClasses @GetFirstClass()" id="img-@CurIndex">
                 @RenderImg(image, false )
                 
                 </div>
@@ -60,10 +60,10 @@
         {
             foreach (var variant in Model.Variants)
             {
-                
+                var ColumnClasses = (Model.Images.Count == 1) ? "col-12 col-lg-12 text-center" : "col-9 col-lg-6";
                 foreach (var image in variant.Images)
                 {
-                    <div data-variant="@variant.Id" class="col-9 @GetFirstClass() col-lg-6 @SelectedVariantClass(variant.Id)" id="img-@variant.Id-@CurIndex">
+                    <div data-variant="@variant.Id" class="@ColumnClasses @GetFirstClass() @SelectedVariantClass(variant.Id)" id="img-@variant.Id-@CurIndex">
                     @RenderImg(image, variant.Id != Model.SelectedVariantId)
                     </div>
                 


### PR DESCRIPTION
[AB#67609](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/67609)
Add fallback to Main product specifications for variants with no specs Add kva information in variant specifications
Fix image display to allow single column when we have only one image Fix image display to remove mobile carousel styling when we only have one image