### PR TITLE
Bugs/68430 68429 mobile sticky filters and product variant image switch fixes

### DIFF
--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Product/Summary.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Product/Summary.cshtml
@@ -34,10 +34,10 @@
          data-context-var="productDetailContext"
          class="product-details">
         <div class="row">
-            <div class="col-md-7 col-lg-8 @(Model.Images.Count > 1 ? "mobile-carousel-container" : "")">
+            <div id="product-gallery" class="col-md-7 col-lg-8 @(Model.Images.Count > 1 ? "mobile-carousel-container" : "")">
                 @Partial("Product", "ImagesLargeGallery", Model)
             </div>
-            <div class="mobile-carousel-thumbnails d-md-none">
+            <div class="mobile-carousel-thumbnails  @(Model.Images.Count > 1 ? "" : "d-none") d-md-none">
                 @Partial("Product", "ThumbsGallery", Model)
             </div>
             <div class="col-md-5 col-lg-4">
@@ -87,14 +87,23 @@
     }
     else
     {
-        var displayNames = Model.Variants.GroupBy(v => v.DisplayName).ToList();
-
-        foreach (var group in displayNames)
-        {
-            var ids = group.Select(v => v.Id).ToArray();
-            <span data-variant="@(String.Join(",", ids))" class="@SelectedVariantClass(ids) h1">@group.Key</span>
+        <h1>
+        @{
+            var displayNames = Model.Variants.GroupBy(v => v.DisplayName).ToList();
+            if (displayNames.Count() > 1) {
+                foreach (var group in displayNames)
+                {
+                    var ids = group.Select(v => v.Id).ToArray();
+                    <span data-variant="@(String.Join(",", ids))" class="@SelectedVariantClass(ids)">@group.Key</span>
+                }
+            }
+            else {
+                var group = displayNames.FirstOrDefault();
+                var ids = group.Select(v => v.Id).ToArray();
+                <span class="single">@group.Key</span>
+            }
         }
-        <h1 data-variant="unavailable" class="d-none">@Model.DisplayName</h1>
+       </h1>
     }
 }
 

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/BaseSelectedFacets.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/BaseSelectedFacets.cshtml
@@ -41,7 +41,8 @@
          data-context="@JsonConvert.SerializeObject(SelectedFacets, new Newtonsoft.Json.Converters.StringEnumConverter())" 
          data-landingpageurls="@JsonConvert.SerializeObject(LandingPageUrls)"
          id="vueSelectedSearchFacets" v-cloak="true">
-        <div v-if="Facets.length" class="card facets-card mb-3 selected-facets">
+        <div class="card facets-card selected-facets"
+            v-bind:class="{'d-lg-none' : !Facets.length}">
             <div class="card-header">
                 @Html.Localize("List-Search", "L_Selection")
                 <a v-if="IsAllRemovable" 

--- a/src/Orckestra.Composer.Website/UI.Package/Sass/Blades/ProductDetail/_product-details.scss
+++ b/src/Orckestra.Composer.Website/UI.Package/Sass/Blades/ProductDetail/_product-details.scss
@@ -1,3 +1,9 @@
+#product-gallery {
+    @include media-breakpoint-down(sm) {
+        height: 122vw;
+    }
+}
+
 .product-details {
     .add-to-wishlist {
         position: absolute;

--- a/src/Orckestra.Composer.Website/UI.Package/Sass/Blades/ProductDetail/_product-details.scss
+++ b/src/Orckestra.Composer.Website/UI.Package/Sass/Blades/ProductDetail/_product-details.scss
@@ -1,6 +1,9 @@
 #product-gallery {
     @include media-breakpoint-down(sm) {
         height: 122vw;
+        &.mobile-carousel-container {
+            height: 94vw;
+        }
     }
 }
 

--- a/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/Search/_facets.scss
+++ b/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/Search/_facets.scss
@@ -90,6 +90,7 @@
     .card-body {
         padding-left: $card-spacer-x / 1.5;
         padding-right: $card-spacer-x / 1.5;
+        min-height: 45px;
     }
 
     .fa-check {
@@ -116,7 +117,7 @@
         padding-top: 10px;
         position: sticky;
         position: -webkit-sticky;
-        top: 205px;
+        top: 193px;
         @include media-breakpoint-up(lg) {
             top: 136px;
           }

--- a/src/Orckestra.Composer.Website/UI.Package/Typescript/Composer.Product/ProductDetail/ProductDetailController.ts
+++ b/src/Orckestra.Composer.Website/UI.Package/Typescript/Composer.Product/ProductDetail/ProductDetailController.ts
@@ -328,12 +328,21 @@ module Orckestra.Composer {
             });
             new Vue({
                 el: `#${elId}`,
+                data: {
+                   dataUpdatedTracker: 1
+                },
                 computed: {
                     KvaAttributeItems() {
-                        return self.context.viewModel.keyVariantAttributeItems;
+                        return this.dataUpdatedTracker && self.context.viewModel.keyVariantAttributeItems;
                     }
                 },
+                mounted() {
+                    self.eventHub.subscribe(self.concern + 'SelectedVariantIdChanged', this.onSelectedVariantIdChanged);
+                },
                 methods: {
+                    onSelectedVariantIdChanged(result) {
+                        this.dataUpdatedTracker += 1;
+                    },
                     KvaColorStyle(value) {
                         var colorStyle = value.ConfiguredValue ? {"background": value.ConfiguredValue} :  {"background": value.Value};
                         return colorStyle;


### PR DESCRIPTION
[AB#68430](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/68430)
[AB#68429](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/68429)
[AB#68476](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/68476)
[AB#68477](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/68477)
-- Search Results Page with "*" keyword
Show the Filters selection section on mobile to prevent a weird gap when it is empty
Removed unnecessary bottom margin of Filters selection section
-- Product Details Page
Hide mobile-carousel-thumbnails div when empty (was causing a height shift at certain times)
Fixed height of image container in mobile to compensate for times when javascript is not fast enough to hide and show the variant images simultaneously
Fixed height of image container if a mobile carousel is present
Fixed the product title markup
Used proper H1 for the title instead of a span with a h1 class
Fix default height of the image container section
Added an update tracker to re-render the kva buttons when they are selected