### PR TITLE
Bugs/68621 selected facets overlap filters mobile

### DIFF
--- a/src/Orckestra.Composer.C1CMS.Queries.Package/Package/App_Data/Razor/Composer/Queries/Merchandising/Facets.cshtml
+++ b/src/Orckestra.Composer.C1CMS.Queries.Package/Package/App_Data/Razor/Composer/Queries/Merchandising/Facets.cshtml
@@ -57,7 +57,7 @@
                             }
 
                             <div v-for="facet in Facets" v-if="facet.IsDisplayed" v-bind:key="facet.FieldName + facet.FacetType"
-                                 class="card  bg-light  mb-3  facets-card"
+                                 class="card mb-3 facets-card"
                                  v-bind:data-facetfieldname="facet.FieldName"
                                  v-bind:data-facettype="facet.FacetType"
                                  v-bind:data-min="facet.StartValue"

--- a/src/Orckestra.Composer.C1CMS.Queries.Package/Package/App_Data/Razor/Composer/Queries/Merchandising/SelectedFacets.cshtml
+++ b/src/Orckestra.Composer.C1CMS.Queries.Package/Package/App_Data/Razor/Composer/Queries/Merchandising/SelectedFacets.cshtml
@@ -1,6 +1,8 @@
 ﻿@inherits Composer.Razor.ComposerRazorFunction
 @using Orckestra.Overture.ServiceModel.SearchQueries
 @using Orckestra.Composer.SearchQuery.Context
+@using Orckestra.Composer.SearchQuery.ViewModels
+@using Orckestra.Composer.Search.ViewModels
 
 @functions {
     public override string FunctionDescription
@@ -15,17 +17,18 @@
 }
 
 @{
-    var browsingViewModel = RequestContext.GetSearchQueryViewModelAsync("Merchandising", QueryName).Result;
+    SearchQueryViewModel browsingViewModel = RequestContext.GetSearchQueryViewModelAsync("Merchandising", QueryName).Result;
     if (browsingViewModel == null)
     {
         return;
     }
+    ProductSearchResultsViewModel productSearchVM = browsingViewModel.ProductSearchResults;
 }
 
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://www.composite.net/ns/function/1.0">
 <head>
 </head>
 <body>
-    @Function("Composer.Search.BaseSelectedFacets", new { FacetSettings = browsingViewModel.FacetSettings })
+    @Function("Composer.Search.BaseSelectedFacets", new { FacetSettings = browsingViewModel.FacetSettings, ProductSearchVM = productSearchVM })
 </body>
 </html>

--- a/src/Orckestra.Composer.C1CMS.Queries.Package/Package/App_Data/Razor/Composer/Queries/ProductSet/Facets.cshtml
+++ b/src/Orckestra.Composer.C1CMS.Queries.Package/Package/App_Data/Razor/Composer/Queries/ProductSet/Facets.cshtml
@@ -55,7 +55,7 @@
                             }
 
                             <div v-for="facet in Facets" v-if="facet.IsDisplayed" v-bind:key="facet.FieldName + facet.FacetType"
-                                 class="card  bg-light  mb-3  facets-card"
+                                 class="card mb-3 facets-card"
                                  v-bind:data-facetfieldname="facet.FieldName"
                                  v-bind:data-facettype="facet.FacetType"
                                  v-bind:data-min="facet.StartValue"

--- a/src/Orckestra.Composer.C1CMS.Queries.Package/Package/App_Data/Razor/Composer/Queries/ProductSet/SelectedFacets.cshtml
+++ b/src/Orckestra.Composer.C1CMS.Queries.Package/Package/App_Data/Razor/Composer/Queries/ProductSet/SelectedFacets.cshtml
@@ -1,6 +1,8 @@
 ﻿@inherits Composer.Razor.ComposerRazorFunction
 @using Orckestra.Overture.ServiceModel.SearchQueries
 @using Orckestra.Composer.SearchQuery.Context
+@using Orckestra.Composer.SearchQuery.ViewModels
+@using Orckestra.Composer.Search.ViewModels
 
 @functions {
     public override string FunctionDescription
@@ -15,17 +17,18 @@
 }
 
 @{
-    var browsingViewModel = RequestContext.GetSearchQueryViewModelAsync("ProductSet", QueryName).Result;
+    SearchQueryViewModel browsingViewModel = RequestContext.GetSearchQueryViewModelAsync("ProductSet", QueryName).Result;
     if (browsingViewModel == null)
     {
         return;
     }
+    ProductSearchResultsViewModel productSearchVM = browsingViewModel.ProductSearchResults;
 }
 
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://www.composite.net/ns/function/1.0">
 <head>
 </head>
 <body>
-    @Function("Composer.Search.BaseSelectedFacets", new { FacetSettings = browsingViewModel.FacetSettings })
+    @Function("Composer.Search.BaseSelectedFacets", new { FacetSettings = browsingViewModel.FacetSettings, ProductSearchVM = productSearchVM })
 </body>
 </html>

--- a/src/Orckestra.Composer.Website/App_Code/FacetHelpers.cshtml
+++ b/src/Orckestra.Composer.Website/App_Code/FacetHelpers.cshtml
@@ -182,7 +182,7 @@
 @helper FacetsModalCollapseBtn()
 {
         <button type="button"
-                class="btn  btn-outline-secondary btn-dropdown  w-100 dropdown-toggle"
+                class="btn  btn-outline-secondary btn-dropdown  btn-block dropdown-toggle"
                 data-toggle="modal"
                 data-target="#facetsModal" aria-expanded="false">
             <span v-if="getFacetsCount()">@Html.Localize("List-Search", "B_FiltersApplied") <span class="badge badge-dark">{{getFacetsCount()}}</span></span>
@@ -212,6 +212,23 @@
                          showMoreText="@Html.Localize("List-Search", "B_ShowMore")"
                          showLessText="@Html.Localize("List-Search", "B_ShowLess")">
             </facets-tree>
+        </div>
+    </div>
+}
+
+@helper SortBy()
+{
+    <div class="dropdown sort-by d-lg-none" v-if="SelectedSortBy">
+        <button class="btn btn-outline-default btn-block dropdown-toggle" id="mobileSortByDropdown" type="button" data-qa="search-sort-by-toggle"
+                data-toggle="dropdown" aria-expanded="true">
+            {{SelectedSortBy.DisplayName}}
+        </button>
+        <div class="dropdown-menu  dropdown-menu-sm-right  dropdown-menu-md-right" aria-labelledby="mobileSortByDropdown" role="menu" data-qa="search-sort-by">
+            <a v-for="sortBy in AvailableSortBys"
+               class="dropdown-item"
+               v-on:click="sortingChanged(sortBy.Url)">
+                {{sortBy.DisplayName}}
+            </a>
         </div>
     </div>
 }

--- a/src/Orckestra.Composer.Website/App_Code/SearchHelpers.cshtml
+++ b/src/Orckestra.Composer.Website/App_Code/SearchHelpers.cshtml
@@ -78,11 +78,11 @@
             <span v-else="v-else">@Html.Localize("List-Search", "B_FiltersShow")</span>
         </button>
         <span class="d-none d-lg-inline">@Html.Localize("List-Search", "L_Sorting")&#160;</span>
-        <button class="btn btn-outline-default dropdown-toggle" type="button" data-qa="search-sort-by-toggle"
+        <button class="btn btn-outline-default dropdown-toggle" id="sortByDropdown" type="button" data-qa="search-sort-by-toggle"
                 data-toggle="dropdown" aria-expanded="true">
             {{SelectedSortBy.DisplayName}}
         </button>
-        <div class="dropdown-menu  dropdown-menu-sm-right  dropdown-menu-md-right" role="menu" data-qa="search-sort-by">
+        <div class="dropdown-menu  dropdown-menu-sm-right  dropdown-menu-md-right" aria-labelledby="sortByDropdown" role="menu" data-qa="search-sort-by">
             <a v-for="sortBy in AvailableSortBys"
                class="dropdown-item"
                v-on:click="sortingChanged(sortBy.Url)">

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/BrowsingCategories/SelectedFacets.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/BrowsingCategories/SelectedFacets.cshtml
@@ -1,6 +1,8 @@
 ﻿@inherits Composer.Razor.ComposerRazorFunction
+@using Composite.AspNet.Razor
 @using Orckestra.Composer.Search.Context
 @using Orckestra.Composer.Search
+@using Orckestra.Composer.Search.ViewModels
 
 @functions {
     public override string FunctionDescription
@@ -11,17 +13,19 @@
 }
 
 @{
-    var categoryBrowsingViewModel = BrowsingRequestContext.GetViewModelAsync().Result;
+    CategoryBrowsingViewModel categoryBrowsingViewModel = BrowsingRequestContext.GetViewModelAsync().Result;
     if (categoryBrowsingViewModel == null)
     {
         return;
     }
+
+    ProductSearchResultsViewModel productSearchVM = categoryBrowsingViewModel.ProductSearchResults;
 }
 
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://www.composite.net/ns/function/1.0">
 <head>
 </head>
 <body>
-    @Function("Composer.Search.BaseSelectedFacets", new { FacetSettings = categoryBrowsingViewModel.FacetSettings, LandingPageUrls = categoryBrowsingViewModel.LandingPageUrls })
+    @Function("Composer.Search.BaseSelectedFacets", new { FacetSettings = categoryBrowsingViewModel.FacetSettings, LandingPageUrls = categoryBrowsingViewModel.LandingPageUrls, ProductSearchVM = productSearchVM })
 </body>
 </html>

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/BrowsingCategories/Summary.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/BrowsingCategories/Summary.cshtml
@@ -29,7 +29,7 @@
     var tabs = new[] { new { Total = model.ProductSearchResults.TotalCount, IsProducts = true }};
     if (summary == null)
     {
-        <div class="@(FullWidth ? "container-fluid": "")  page-summary" 
+        <div class="@(FullWidth ? "container-fluid": "")  page-summary mb-4 sps sps--abv" 
              data-oc-controller="Product.SearchSummary"
              id="vueSearchSummary" data-context="@JsonConvert.SerializeObject(tabs)"
              v-cloak="true">

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Grids/SearchGrid.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Grids/SearchGrid.cshtml
@@ -18,10 +18,10 @@
     </head>
     <body>
         <div class="row searchgrid">
-            <div id="leftCol" class="col-12  col-lg-3 mt-3  facets-col sps sticky-top" data-sps-offset="136">
+            <div id="leftCol" class="col-12  col-lg-3 facets-col sps sticky-top" data-sps-offset="136">
                 @Markup(LeftPart)
             </div>
-            <div id="rightCol" class="col-12  col-lg-9 mt-3">
+            <div id="rightCol" class="col-12  col-lg-9 sps sticky-top">
                 @Markup(RightPart)
             </div>
         </div>

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/BaseSearchResults.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/BaseSearchResults.cshtml
@@ -60,14 +60,11 @@
         <div class="overlay" v-if="isLoading"></div>
         @if (ShowPagination)
         {
-            <div class="row filters-row mb-4" v-if="TotalCount > 0">
-                <div class="col-6 d-lg-none">
-                    @FacetHelpers.FacetsModalCollapseBtn()
-                </div>
+            <div class="row filters-row mb-4 d-none d-lg-flex" v-if="TotalCount > 0">
                 <div class="col-6">
                     @SearchHelpers.SortBy()
                 </div>
-                <div class="col-6 d-none d-lg-block">
+                <div class="col-6">
                     @SearchHelpers.PaginationDropdown()
                 </div>
             </div>

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/BaseSelectedFacets.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/BaseSelectedFacets.cshtml
@@ -15,6 +15,29 @@
     [FunctionParameter(Label = "", Help = "", DefaultValue = null)]
     public List<string> LandingPageUrls { get; set; }
 
+    [FunctionParameter(Label = "", Help = "", DefaultValue = null)]
+    public ProductSearchResultsViewModel ProductSearchVM { get; set; }
+
+    
+    public SelectedSortBy SelectedSortBy { 
+        get {
+            return ProductSearchVM.SelectedSortBy;
+        }
+    }
+
+    
+    public IList<SortBy> AvailableSortBys { 
+        get {
+            return ProductSearchVM.AvailableSortBys;
+        }
+    }
+
+    
+    public long TotalCount { 
+        get {
+            return ProductSearchVM.TotalCount;
+        }
+    }
 
     public SelectedFacets SelectedFacets
     {
@@ -40,6 +63,9 @@
     <div data-oc-controller="Product.SelectedSearchFacets" 
          data-context="@JsonConvert.SerializeObject(SelectedFacets, new Newtonsoft.Json.Converters.StringEnumConverter())" 
          data-landingpageurls="@JsonConvert.SerializeObject(LandingPageUrls)"
+         data-available-sort="@JsonConvert.SerializeObject(AvailableSortBys, new Newtonsoft.Json.Converters.StringEnumConverter())"
+         data-selected-sort="@JsonConvert.SerializeObject(SelectedSortBy, new Newtonsoft.Json.Converters.StringEnumConverter())"
+         data-items-count="@(TotalCount)"
          id="vueSelectedSearchFacets" v-cloak="true">
         <div class="card facets-card selected-facets"
             v-bind:class="{'d-lg-none' : !Facets.length}">
@@ -69,6 +95,14 @@
                         </span>
                     </li>
                 </ul>
+            </div>
+        </div>
+        <div class="row filters-row mb-4 mt-3 d-lg-none" v-if="TotalCount > 0">
+            <div class="col-6">
+                @FacetHelpers.FacetsModalCollapseBtn()
+            </div>
+            <div class="col-6">
+                @FacetHelpers.SortBy()
             </div>
         </div>
     </div>

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/ContentTabs.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/ContentTabs.cshtml
@@ -159,7 +159,8 @@
          data-searchQuery="@SearchRequestContext.SearchQuery"
          data-suggestedTabs="@JsonConvert.SerializeObject(vm.SuggestedTabs)"
          data-total="@vm.Total"
-         v-cloak="true">
+         v-cloak="true"
+         class="sps sps--abv">
         <div class="container-md">
             <template v-if="IsProductsCorrected">
                 <h2>@Html.Localized("List-Search", "L_NoResultsFor", "{{SearchQuery}}")</h2>

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/SelectedFacets.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/SelectedFacets.cshtml
@@ -13,10 +13,14 @@
     SearchViewModel ProductsSearchViewModel => SearchRequestContext.ProductsSearchViewModel;
 }
 
+@{ 
+    ProductSearchResultsViewModel productSearchVM = ProductsSearchViewModel.ProductSearchResults;
+}
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://www.composite.net/ns/function/1.0">
 <head>
 </head>
 <body>
-    @Function("Composer.Search.BaseSelectedFacets", new { FacetSettings = ProductsSearchViewModel.FacetSettings })
+    @Function("Composer.Search.BaseSelectedFacets", new { FacetSettings = ProductsSearchViewModel.FacetSettings, ProductSearchVM = productSearchVM })
 </body>
 </html>

--- a/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/Summary.cshtml
+++ b/src/Orckestra.Composer.Website/App_Data/Razor/Composer/Search/Summary.cshtml
@@ -34,7 +34,7 @@
 <head>
 </head>
 <body>
-    <div class="island" data-oc-controller="Product.SearchSummary" id="vueSearchSummary" data-context="@JsonConvert.SerializeObject(ProductsSearchViewModel.ProductSearchResults)" v-cloak="true">
+    <div class="island mb-4 sps sps--abv" data-oc-controller="Product.SearchSummary" id="vueSearchSummary" data-context="@JsonConvert.SerializeObject(ProductsSearchViewModel.ProductSearchResults)" v-cloak="true">
         <template v-if="totalCount > 0">
             @{
                 var corrected = ProductsSearchViewModel.ProductSearchResults.CorrectedSearchTerms;

--- a/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/Search/_content-tabs.scss
+++ b/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/Search/_content-tabs.scss
@@ -15,9 +15,16 @@
   &.sps--blw {
     position: sticky;
     position: -webkit-sticky;
-    top: 136px;
+    top: 115px;
+    padding-top:10px;
+    padding-bottom: 10px;
     background: #fff;
     z-index: 1030;
+    @include media-breakpoint-up(lg){
+      top: 136px;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
     .search-tabs {
       display: none;
     }
@@ -30,7 +37,7 @@
   position: -webkit-sticky;
   max-height: calc(100vh - 419px);
   overflow: hidden scroll;
-  top: 115px;
+  top: 179px;
   background-color: #fff;
   z-index: 1042;
   @include media-breakpoint-up(lg) {
@@ -42,8 +49,7 @@
   &.sps--blw {
     max-height: calc(100vh - 193px);
     @include media-breakpoint-down(md) {
-      top: 115px;
-      z-index: unset;
+      top: 179px;
     }
   }
 }

--- a/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/Search/_content-tabs.scss
+++ b/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/Search/_content-tabs.scss
@@ -11,6 +11,19 @@
   }
 }
 
+#vueSearchSummary {
+  &.sps--blw {
+    position: sticky;
+    position: -webkit-sticky;
+    top: 136px;
+    background: #fff;
+    z-index: 1030;
+    .search-tabs {
+      display: none;
+    }
+  }
+}
+
 #leftCol {
   transition: .4s ease-in-out, opacity .1s;
   position: sticky;
@@ -21,13 +34,17 @@
   background-color: #fff;
   z-index: 1042;
   @include media-breakpoint-up(lg) {
-    top: 136px;
+    top: 193px;
     z-index: unset;
   }
   
   
   &.sps--blw {
-    max-height: calc(100vh - 136px);
+    max-height: calc(100vh - 193px);
+    @include media-breakpoint-down(md) {
+      top: 115px;
+      z-index: unset;
+    }
   }
 }
 

--- a/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/Search/_facets.scss
+++ b/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/Search/_facets.scss
@@ -111,32 +111,22 @@
     }
 }
 
-#rightCol {
-    &.sps--blw {
-        position: sticky;
-        position: -webkit-sticky;
-    }
-    
-
-    @include media-breakpoint-up(lg){
-        &.sps--blw {
-            position: relative;
-        }
-    }
-}
 
 .search-results {
     .filters-row {
-        height: 55px;
-        padding-top: 20px;
-        top: 193px;
-        @include media-breakpoint-up(lg) {
+        .sps--blw & {
             position: sticky;
             position: -webkit-sticky;
-            top: 178px;
-            height: 75px;
-          }
-        z-index: 1000;
+            height: 55px;
+            padding-top: 20px;
+            top: 257px;
+            @include media-breakpoint-up(lg) {
+                top: 178px;
+                height: 75px;
+            }
+            z-index: 1020;
+        }
+        
         background-color: #fff;
 
         .sort-by {

--- a/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/Search/_facets.scss
+++ b/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/Search/_facets.scss
@@ -111,18 +111,37 @@
     }
 }
 
+#rightCol {
+    &.sps--blw {
+        position: sticky;
+        position: -webkit-sticky;
+    }
+    
+
+    @include media-breakpoint-up(lg){
+        &.sps--blw {
+            position: relative;
+        }
+    }
+}
+
 .search-results {
     .filters-row {
         height: 55px;
-        padding-top: 10px;
-        position: sticky;
-        position: -webkit-sticky;
+        padding-top: 20px;
         top: 193px;
         @include media-breakpoint-up(lg) {
-            top: 136px;
+            position: sticky;
+            position: -webkit-sticky;
+            top: 178px;
+            height: 75px;
           }
         z-index: 1000;
         background-color: #fff;
+
+        .sort-by {
+            white-space: nowrap;
+        }
     }
 
     .sort-by .btn {
@@ -139,7 +158,7 @@
 
 @include media-breakpoint-up(lg) {
     .facets-col {
-        margin-top: -55px;
+        //margin-top: -55px;
 
         &.collapse {
             display: block;


### PR DESCRIPTION
[AB#68621](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/68621)
[AB#68777](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/68777)
Fix layout and CSS for a nice sticky layout on desktop
Copied and adaptted the dropdown buttons to select filters and Sorting options for the mobile view, to the div id leftCol
Added access to SelectedSortBy and AvailableSortBys parameters to raor functions
Added those parameters to the vue component as well
Fixed some styling issues when scrolling with - allow to see the search title with result count
Fix whitespace on desktop to allow View Filter button and SortBy button to be on the same line