### PR TITLE
Fix autosuggest dropdown z-index

### DIFF
--- a/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/_header.scss
+++ b/src/Orckestra.Composer.Website/UI.Package/Sass/Custom/_header.scss
@@ -33,7 +33,7 @@
 
 .masthead {
     position: relative;
-    z-index: 1030;
+    z-index: 1099;
     top: 0;
     transition: top .5s ease-in-out;
 


### PR DESCRIPTION
[AB#69708](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/69708)
Fix autosuggest dropdown z-index to be above most of the other z positioned elements, mobile and other device sizes