### PR TITLE
Update BreadcrumbViewService to use SitemapNavigator

### DIFF
--- a/src/Orckestra.Composer.CompositeC1/Controllers/HeaderBaseController.cs
+++ b/src/Orckestra.Composer.CompositeC1/Controllers/HeaderBaseController.cs
@@ -26,17 +26,20 @@ namespace Orckestra.Composer.CompositeC1.Controllers
 
         public virtual ActionResult PageHeader()
         {
-            var page = PageService.GetPage(SitemapNavigator.CurrentPageId);
-            var canonicalUrl = page != null ? UrlUtils.ToAbsolute(PageService.GetPageUrl(page.Id)) : string.Empty;
-
-            var pageHeaderViewModel = new PageHeaderViewModel
+            using (var connection = new DataConnection())
             {
-                PageTitle = page.Title,
-                NoIndex = string.IsNullOrWhiteSpace(canonicalUrl),
-                CanonicalUrl = canonicalUrl
-            };
+                var currentPageNode = connection.SitemapNavigator.CurrentPageNode;
+                var pageUrl = currentPageNode?.Url;
+                var canonicalUrl = !string.IsNullOrEmpty(pageUrl) ? UrlUtils.ToAbsolute(pageUrl) : string.Empty;
+                var pageHeaderViewModel = new PageHeaderViewModel
+                {
+                    PageTitle = currentPageNode?.Title,
+                    NoIndex = string.IsNullOrWhiteSpace(canonicalUrl),
+                    CanonicalUrl = canonicalUrl
+                };
 
-            return View("PageHeader", pageHeaderViewModel);
+                return View("PageHeader", pageHeaderViewModel);
+            }
         }
 
         protected virtual bool IsPageIndexed()

--- a/src/Orckestra.Composer.CompositeC1/Orckestra.Composer.CompositeC1.csproj
+++ b/src/Orckestra.Composer.CompositeC1/Orckestra.Composer.CompositeC1.csproj
@@ -250,6 +250,8 @@
     <Compile Include="Services\DataQuery\IDataQueryService.cs" />
     <Compile Include="Services\Cache\ICacheService.cs" />
     <Compile Include="Services\Cache\ICacheStore.cs" />
+    <Compile Include="Services\DataConnectionService.cs" />
+    <Compile Include="Services\IDataConnectionService.cs" />
     <Compile Include="Services\IScheduler.cs" />
     <Compile Include="Services\PreviewMode\PreviewModeService.cs" />
     <Compile Include="Services\PreviewMode\IPreviewModeService.cs" />

--- a/src/Orckestra.Composer.CompositeC1/Plugin.cs
+++ b/src/Orckestra.Composer.CompositeC1/Plugin.cs
@@ -56,6 +56,7 @@ namespace Orckestra.Composer.CompositeC1
             host.Register<CultureService, ICultureService>(ComponentLifestyle.Singleton);
             host.Register<GoogleAnalyticsNavigationUrlProvider>();
             host.Register<NavigationMapper, INavigationMapper>();
+            host.Register<DataConnectionService, IDataConnectionService>(ComponentLifestyle.Singleton);
 
             host.Register<SearchUrlProvider, ISearchUrlProvider>();
             host.Register<CategoryBrowsingUrlProvider, ICategoryBrowsingUrlProvider>();

--- a/src/Orckestra.Composer.CompositeC1/Services/DataConnectionService.cs
+++ b/src/Orckestra.Composer.CompositeC1/Services/DataConnectionService.cs
@@ -1,0 +1,41 @@
+﻿using Composite.Data;
+using System;
+using System.Globalization;
+
+namespace Orckestra.Composer.CompositeC1.Services
+{
+    public class DataConnectionService: IDataConnectionService
+    {
+        public IDataConnectionAdapter GetDataConnection(CultureInfo culture)
+        {
+            return new DataConnectionAdapter(culture);
+        }
+    }
+
+    public interface IDataConnectionAdapter : IDisposable
+    {
+        SitemapNavigator SitemapNavigator { get; }
+        PageNode GetPageNodeById(Guid id);
+    }
+
+    public class DataConnectionAdapter : IDataConnectionAdapter
+    {
+        private readonly DataConnection _dataConnection;
+        public DataConnectionAdapter(CultureInfo culture)
+        {
+            _dataConnection = new DataConnection(culture);
+        }
+
+        public virtual SitemapNavigator SitemapNavigator => _dataConnection.SitemapNavigator;
+
+        public virtual PageNode GetPageNodeById(Guid id)
+        {
+            return SitemapNavigator.GetPageNodeById(id);
+        }
+
+        public void Dispose()
+        {
+            _dataConnection.Dispose();
+        }
+    }
+}

--- a/src/Orckestra.Composer.CompositeC1/Services/IDataConnectionService.cs
+++ b/src/Orckestra.Composer.CompositeC1/Services/IDataConnectionService.cs
@@ -1,0 +1,10 @@
+﻿using Composite.Data;
+using System.Globalization;
+
+namespace Orckestra.Composer.CompositeC1.Services
+{
+    public interface IDataConnectionService
+    {
+        IDataConnectionAdapter GetDataConnection(CultureInfo cultore);
+    }
+}

--- a/tests/Orckestra.Composer.CompositeC1.Tests/Mocks/DataConnectionServiceMock.cs
+++ b/tests/Orckestra.Composer.CompositeC1.Tests/Mocks/DataConnectionServiceMock.cs
@@ -1,0 +1,41 @@
+﻿using Composite.Core.Implementation;
+using Composite.Data;
+using Composite.Data.Types;
+using Moq;
+using Orckestra.Composer.CompositeC1.Services;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Orckestra.Composer.CompositeC1.Tests.Mocks
+{
+    public class DataConnectionServiceMock : IDataConnectionService
+    {
+        private readonly IEnumerable<IPage> _pagesSource;
+        public DataConnectionServiceMock(IEnumerable<IPage> pagesSource)
+        {
+            _pagesSource = pagesSource;
+        }
+
+        public IDataConnectionAdapter GetDataConnection(CultureInfo culture)
+        {
+            var mockDC = new Mock<IDataConnectionAdapter>();
+            var navigator = new Mock<SitemapNavigatorImplementation>();
+            mockDC.Setup(sm => sm.GetPageNodeById(It.IsAny<Guid>())).Returns<Guid>((id) =>
+            {
+                var page = _pagesSource.FirstOrDefault(p => p.Id == id) as PageMock;
+                if (page == null) return null;
+                var parentPage = _pagesSource.FirstOrDefault(p => page.ParentPageId == p.Id) as PageMock;
+                var parentPageNode = parentPage != null ? new PageNode(parentPage, navigator.Object) : null;
+                var pageNodeMock = new Mock<PageNode>(page, navigator.Object);
+                pageNodeMock.SetupGet(p => p.ParentPage).Returns(parentPageNode);
+                pageNodeMock.SetupGet(p => p.Page).Returns(page);
+                pageNodeMock.SetupGet(p => p.MenuTitle).Returns(page.MenuTitle);
+                pageNodeMock.SetupGet(p => p.Url).Returns(page.Url);
+                return pageNodeMock.Object;
+            });
+            return mockDC.Object;
+        }
+    }
+}

--- a/tests/Orckestra.Composer.CompositeC1.Tests/Orckestra.Composer.CompositeC1.Tests.csproj
+++ b/tests/Orckestra.Composer.CompositeC1.Tests/Orckestra.Composer.CompositeC1.Tests.csproj
@@ -84,7 +84,7 @@
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Common, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\C1CMS.Assemblies.6.12.8122.18346\lib\net471\Microsoft.Practices.EnterpriseLibrary.Common.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\C1CMS.Assemblies.6.12.8122.18346\lib\net471\Microsoft.Practices.EnterpriseLibrary.Logging.dll</HintPath>
@@ -178,6 +178,7 @@
     </Compile>
     <Compile Include="Factory\ProductPromotionsFactory_BuildProductBadgeValues.cs" />
     <Compile Include="Mappers\FacetsMapper_ConvertToFacetSetting.cs" />
+    <Compile Include="Mocks\DataConnectionServiceMock.cs" />
     <Compile Include="Mocks\MainMenuMock.cs" />
     <Compile Include="Mocks\ISiteConfigurationMetaMock.cs" />
     <Compile Include="Mocks\PageServiceMock.cs" />

--- a/tests/Orckestra.Composer.CompositeC1.Tests/Services/BreadcrumbViewService/BreadcrumbViewService_CreateBreadcrumbViewModel.cs
+++ b/tests/Orckestra.Composer.CompositeC1.Tests/Services/BreadcrumbViewService/BreadcrumbViewService_CreateBreadcrumbViewModel.cs
@@ -7,14 +7,12 @@ using NUnit.Framework;
 using Orckestra.Composer.CompositeC1.Services;
 using Orckestra.Composer.CompositeC1.Tests.Mocks;
 using Orckestra.Composer.Services.Breadcrumb;
+using Orckestra.Composer.ViewModels.Breadcrumb;
 using Orckestra.ExperienceManagement.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using static Orckestra.Composer.Utils.MessagesHelper.ArgumentException;
-using static Orckestra.Composer.Utils.ExpressionUtility;
-using Orckestra.Composer.ViewModels.Breadcrumb;
 using System.Linq.Expressions;
 
 namespace Orckestra.Composer.CompositeC1.Tests.Services.BreadcrumbViewService
@@ -51,7 +49,10 @@ namespace Orckestra.Composer.CompositeC1.Tests.Services.BreadcrumbViewService
 
             var dataSource = BuildPageDataSource(contentPageId);
             var pageServiceMock = new PageServiceMock(dataSource);
+
+            var dataConnectionServiceMcok = new DataConnectionServiceMock(dataSource);
             Container.Use<IPageService>(pageServiceMock);
+            Container.Use<IDataConnectionService>(dataConnectionServiceMcok);
 
             var mockedSiteConfiguration = new Mock<ISiteConfiguration>();
 


### PR DESCRIPTION
Update BreadcrumbViewService to use SitemapNavigator to be able to render fallback language page urls

[AB#71774](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/71774)